### PR TITLE
Fix cleanup logic and typos

### DIFF
--- a/lib/constants/strings/route_constants.dart
+++ b/lib/constants/strings/route_constants.dart
@@ -1,5 +1,5 @@
 class RouteConstants {
-  static const String spalsh = "splash";
+  static const String splash = "splash";
   static const String login = "login";
   static const String home = "home";
   static const String search = "search";

--- a/lib/db/app_config/appconfig.dart
+++ b/lib/db/app_config/appconfig.dart
@@ -56,7 +56,7 @@ class AppConfig with _$AppConfig, IsarIdMixin {
     @Enumerated(EnumType.name)
     DynamicSchemeVariant themeVariant,
 
-    // Exprimental
+    // Experimental
     @Default(false) bool enableDragNDrop,
 
     //? Local App States

--- a/lib/db/clipboard_item/clipboard_item.dart
+++ b/lib/db/clipboard_item/clipboard_item.dart
@@ -201,8 +201,8 @@ class ClipboardItem with _$ClipboardItem, IsarIdMixin {
   /// Removes the associated file.
   Future<void> cleanUp() async {
     try {
-      if (localPath != null && type == ClipItemType.file ||
-          type == ClipItemType.media) {
+      if (localPath != null &&
+          (type == ClipItemType.file || type == ClipItemType.media)) {
         final file = File(localPath!);
         if (await file.exists()) {
           await file.delete();

--- a/test/clipboard_item_test.dart
+++ b/test/clipboard_item_test.dart
@@ -1,0 +1,41 @@
+import 'dart:io';
+
+import 'package:copycat_base/db/clipboard_item/clipboard_item.dart';
+import 'package:copycat_base/enums/clip_type.dart';
+import 'package:copycat_base/enums/platform_os.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ClipboardItem.cleanUp', () {
+    test('does nothing when localPath is null', () async {
+      final item = ClipboardItem(
+        created: DateTime.now(),
+        modified: DateTime.now(),
+        type: ClipItemType.text,
+        os: PlatformOS.linux,
+      );
+
+      await item.cleanUp();
+    });
+
+    test('deletes existing file at localPath', () async {
+      final tempDir = await Directory.systemTemp.createTemp('clipboard_test');
+      final tempFile = File('${tempDir.path}/sample.txt');
+      await tempFile.writeAsString('hello');
+
+      final item = ClipboardItem(
+        created: DateTime.now(),
+        modified: DateTime.now(),
+        type: ClipItemType.file,
+        os: PlatformOS.linux,
+        localPath: tempFile.path,
+      );
+
+      expect(await tempFile.exists(), isTrue);
+      await item.cleanUp();
+      expect(await tempFile.exists(), isFalse);
+
+      await tempDir.delete(recursive: true);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- fix typo in route constant `spalsh`
- correct boolean logic in `ClipboardItem.cleanUp`
- fix typo in `AppConfig` comment
- add tests for `ClipboardItem.cleanUp`

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f53aac2ac832dac9f3a0b6004f150